### PR TITLE
add missing dependency to example project

### DIFF
--- a/example/addons.make
+++ b/example/addons.make
@@ -1,0 +1,1 @@
+ofxTiming


### PR DESCRIPTION
Just minor fix : examples needs self addon dependency in order to compile.
